### PR TITLE
add travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+install: "pip install -r requirements.txt"
+script: nosetests


### PR DESCRIPTION
This pull request adds a travis-ci config file that will run all tests for Python 2.6 and 2.7 whenever somebody pushes to the repository. But before that will happen, travis-ci must be configured to test the repository. See the first few steps of the [getting started guide](http://docs.travis-ci.com/user/getting-started/) for details.
