### PR TITLE
support matching on different sets of expressions

### DIFF
--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -12,6 +12,9 @@ ARCHIVE_DIR = "archives"
 ml_exp = re.compile('/([\w-]*)/$')
 
 gz_exp = re.compile('href="(\d\d\d\d-\w*\.txt\.gz)"')
+ietf_ml_exp = re.compile('href="([\d-]+.mail)"')
+
+mailing_list_path_expressions = [gz_exp, ietf_ml_exp]
 
 def get_list_name(url):
     url = url.rstrip()
@@ -33,7 +36,9 @@ def collect_from_url(url):
     response = urllib2.urlopen(url)
     html = response.read()
 
-    results = gz_exp.findall(html)
+    results = []
+    for exp in mailing_list_path_expressions:
+      results.extend(exp.findall(html))
 
     pp(results)
 
@@ -83,10 +88,12 @@ def unzip_archive(url):
 def open_list_archives(url):
     list_name = get_list_name(url)
     arc_dir = archive_directory(list_name)
+    
+    file_extensions = [".txt", ".mail"]
 
     txts = [os.path.join(arc_dir,fn) for fn
             in os.listdir(arc_dir)
-            if fn.endswith('.txt')]
+            if any([fn.endswith(extension) for extension in file_extensions])]
 
     print 'Opening %d archive files' % (len(txts))
     arch = [parse.open_mail_archive(txt) for txt in txts]

--- a/bigbang/parse.py
+++ b/bigbang/parse.py
@@ -46,4 +46,4 @@ def get_date(message):
         return date
     except TypeError:
         print ds
-        import pdb;pdb.set_trace()
+        #import pdb;pdb.set_trace()

--- a/bin/plot_activity.py
+++ b/bin/plot_activity.py
@@ -8,7 +8,10 @@ import numpy as np
 import math
 import pytz
 
-url = "http://mail.scipy.org/pipermail/scipy-dev/"
+URLS_FILE = "urls.txt"
+for url in open(URLS_FILE):
+    url = url.rstrip()
+    break  # just grab the first one, for now
 
 messages = mailman.open_list_archives(url)
 


### PR DESCRIPTION
In particular, change mailman.py library to use different regular expressions, for finding links to text archives and for the filenames of the archive files themselves.
