### PR TITLE
first pass at a small notebook for graphing top senders in a list

### DIFF
--- a/examples/Analyzing Mail Senders.ipynb
+++ b/examples/Analyzing Mail Senders.ipynb
@@ -1,0 +1,168 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:40b9ca073db60013a98e2f1c98bb2c805f7be2202c6b5c6dd0ae574ab7ef223e"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "\n",
+      "This notebook shows how BigBang can help you explore the senders in a mailing list archive.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "First, use this IPython magic to tell the notebook to display matplotlib graphics inline. This is a nice way to display results."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%matplotlib inline"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Import the BigBang modules as needed, as well as Python libraries for statistics and visualization."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import bigbang.mailman as mailman\n",
+      "import bigbang.graph as graph\n",
+      "from bigbang.process import *\n",
+      "from bigbang.parse import get_date\n",
+      "import pandas as pd\n",
+      "import datetime\n",
+      "import matplotlib.pyplot as plt\n",
+      "import numpy as np\n",
+      "import math\n",
+      "import pytz\n",
+      "import pickle\n",
+      "import os"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "As before, let's load the data for analysis."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "urls = [\"http://www.ietf.org/mail-archive/text/ietf-privacy/\"] # use this small IETF list to start with\n",
+      "\n",
+      "activities = []\n",
+      "\n",
+      "saved_path =  '../save-ietf-privacy.p'\n",
+      "\n",
+      "if os.path.exists(saved_path):\n",
+      "    activities = pickle.load(open(saved_path,'rb'))\n",
+      "else:\n",
+      "    mlists = [mailman.open_list_archives(url,\"../archives\") for url in urls]\n",
+      "    activities = [(activity(ml),compute_ascendancy(ml)) for ml in mlists]\n",
+      "    pickle.dump(activities,open(saved_path,'wb'))\n"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Let's start with a plot of the number of emails sent each day. (For a less active list, we don't need to aggregate or average to still get a sense of the activity.)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.figure(figsize=(12.5, 7.5))\n",
+      "\n",
+      "for i, ((activity,dates,froml),(ascendancy,capacity)) in enumerate(activities):\n",
+      "\n",
+      "    colors = 'rgbkm'\n",
+      "\n",
+      "    total_activity = np.sum(activity,0)\n",
+      "\n",
+      "    plt.plot_date(\n",
+      "        #use convolve?\n",
+      "        dates,\n",
+      "        total_activity,'-'+colors[i],\n",
+      "        label=mailman.get_list_name(urls[i]) + ' activity',xdate=True)\n",
+      "\n",
+      "plt.legend()\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "---\n",
+      "\n",
+      "Now, let's see: who are the authors of the most messages to this list?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from operator import itemgetter\n",
+      "\n",
+      "objects = [{'from': el, 'sum': 0} for el in activities[0][0][2]]\n",
+      "for index, element in enumerate(activities[0][0][0]):  # sum the messages for each \"From\" address\n",
+      "    objects[index]['sum'] = sum(element)\n",
+      "    objects.sort(key=itemgetter('sum'), reverse=True)\n",
+      "\n",
+      "froms = [el['from'] for el in objects if el['sum'] > 15]  # filter for people who've sent more than 15 messages\n",
+      "sums = [el['sum'] for el in objects if el['sum'] > 15]\n",
+      "\n",
+      "y_pos = np.arange(len(froms))\n",
+      "plt.barh(y_pos, sums) # horizontal bar chart\n",
+      "plt.yticks(y_pos, froms)\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This might be useful for seeing the distribution (does the top message sender dominate?) or for identifying key participants to talk to.\n",
+      "\n",
+      "---"
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
As a separate notebook, some steps for looking at the senders of messages in a list.

This notebook just creates a chart of the top senders and their number of messages for a single small list, but it's a place to start. I would likely add next: 
- charts of the distribution of senders
- code for guessing / explicitly combining addresses that represent the same person

I'm not crazy about how clean this code is. It feels natural to me to turn a multi-dimensional array into a list of objects/dictionaries with named fields, but then I immediately turn around and turn it back into lists, because that's what matplotlib requires. (It might be that using pandas visualization, we could use DataFrames/Series which have named columns and allow you to plot them without too much array conversion.)
