### PR TITLE
OutOfBoundsDatetime exception handling for messages with invalid timestamps

### DIFF
--- a/bigbang/archive.py
+++ b/bigbang/archive.py
@@ -56,7 +56,7 @@ class Archive(object):
             self.data['Date'] = pd.to_datetime(self.data['Date'], utc=True)
         except pd.tslib.OutOfBoundsDatetime:
             # otherwise malformed dates will prevent archive initialization
-            self.data['Date'] = None
+            self.data['Date'] = pd.np.nan
         self.data.drop_duplicates(inplace=True)
 
         # Drops any entries with no Date field.

--- a/bigbang/archive.py
+++ b/bigbang/archive.py
@@ -52,7 +52,11 @@ class Archive(object):
         elif isinstance(data, str):
             self.data = mailman.load_data(data,archive_dir=archive_dir,mbox=mbox)
          
-        self.data['Date'] = pd.to_datetime(self.data['Date'], utc=True)
+        try:
+            self.data['Date'] = pd.to_datetime(self.data['Date'], utc=True)
+        except pd.tslib.OutOfBoundsDatetime:
+            # otherwise malformed dates will prevent archive initialization
+            self.data['Date'] = None
         self.data.drop_duplicates(inplace=True)
 
         # Drops any entries with no Date field.


### PR DESCRIPTION
This PR prevents archive initialization from being halted due to a message with a malformed timestamp. It addresses this issue:

https://github.com/datactive/bigbang/issues/277

Having a "justworks" flag to allow the user to ignore/accept errors would be ideal, but for now I figured treating invalid dates the same as missing dates seemed like a good fix.