### PR TITLE
provenance-tracking feature for mailing list crawls

### DIFF
--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -86,7 +86,11 @@ def collect_from_url(url,archive_dir="../archives"):
 
     if has_archives:
         unzip_archive(url)
-        data = open_list_archives(url)
+        try:
+            data = open_list_archives(url)
+        except MissingDataException as e:   # don't strictly need to open the archives during the collection process, so catch the Exception and return
+            print e
+            return None
 
         # hard coding the archives directory in too many places
         # need to push this default to a configuration file

--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -81,6 +81,7 @@ def collect_from_url(url,archive_dir="../archives"):
     try:
         has_archives = collect_archive_from_url(url, archive_dir)
     except urllib2.HTTPError as e:
+        # BUG: this error code/message is misleading
         print "HTTP 404 Error: %s" % (url)
         return None
 

--- a/bigbang/w3crawl.py
+++ b/bigbang/w3crawl.py
@@ -85,7 +85,7 @@ def normalize_mailing_list_url(url):
     
     return url
 
-def collect_from_url(url, base_arch_dir="archives"):
+def collect_from_url(url, base_arch_dir="archives", notes=None):
     """
     Collects W3C mailing list archives from a particular mailing list URL.
 
@@ -116,7 +116,7 @@ def collect_from_url(url, base_arch_dir="archives"):
 
     # directory for downloaded files
     arc_dir = bigbang.mailman.archive_directory(base_arch_dir, list_name)
-    bigbang.mailman.populate_provenance(directory=arc_dir, list_name=list_name, list_url=url)
+    bigbang.mailman.populate_provenance(directory=arc_dir, list_name=list_name, list_url=url, notes=notes)
 
     for link in time_period_indices:
         link_url = urlparse.urljoin(url, link)

--- a/bigbang/w3crawl.py
+++ b/bigbang/w3crawl.py
@@ -3,7 +3,6 @@ import urllib
 import gzip
 import re
 import os
-from . import parse
 import urlparse
 import logging
 from bs4 import BeautifulSoup
@@ -12,9 +11,9 @@ import email
 import email.parser
 import mailbox
 import time
-import mailman
+import bigbang.mailman
 import dateutil
-
+from . import parse
 
 class W3cMailingListArchivesParser(email.parser.Parser):
     parse = None
@@ -93,15 +92,15 @@ def collect_from_url(url, base_arch_dir="archives"):
     Logs an error and returns False if no messages can be collected.
     """
     url = normalize_mailing_list_url(url)
-    list_name = mailman.get_list_name(url)
-    logging.info("Getting W3C list archive for %s" % list_name)
+    list_name = bigbang.mailman.get_list_name(url)
+    logging.info("Getting W3C list archive for %s", list_name)
 
     try:
         response = urllib2.urlopen(url)
         html = response.read()
         soup = BeautifulSoup(html)
     except urllib2.HTTPError as exception:
-        logging.error('Error in loading W3C list archive page for %s: %s' % (url, exception.message))
+        logging.exception('Error in loading W3C list archive page for %s', url)
         return False
 
     try:
@@ -109,14 +108,15 @@ def collect_from_url(url, base_arch_dir="archives"):
         rows = soup.select('tbody tr')
         for row in rows:
             link = row.select('td:nth-of-type(1) a')[0].get('href')
-            logging.info("Found time period archive page: %s" % link)
+            logging.info("Found time period archive page: %s", link)
             time_period_indices.append(link)
     except Exception as exception:
-        logging.error('Error in parsing list archives for %s: %s' % (url, exception.message))
+        logging.exception('Error in parsing list archives for %s', url)
         return False
 
     # directory for downloaded files
-    arc_dir = mailman.archive_directory(base_arch_dir, list_name)
+    arc_dir = bigbang.mailman.archive_directory(base_arch_dir, list_name)
+    bigbang.mailman.populate_provenance(directory=arc_dir, list_name=list_name, list_url=url)
 
     for link in time_period_indices:
         link_url = urlparse.urljoin(url, link)
@@ -133,10 +133,9 @@ def collect_from_url(url, base_arch_dir="archives"):
         # looks like we've already downloaded this timeperiod
         if os.path.isfile(mbox_path):
             logging.info(
-                'Looks like %s already exists, moving on.' %
-                mbox_path)
+                'Looks like %s already exists, moving on.', mbox_path)
             continue
-        logging.info('Downloading messages to archive to %s.' % mbox_path)
+        logging.info('Downloading messages to archive to %s.', mbox_path)
 
         message_links = list()
         messages = list()
@@ -165,4 +164,10 @@ def collect_from_url(url, base_arch_dir="archives"):
         finally:
             mbox.unlock()
 
-        logging.info('Saved ' + year_month_mbox)
+        logging.info('Saved %s', year_month_mbox)
+
+    # assumes all archives were downloaded if no exceptions have been thrown
+    provenance = bigbang.mailman.access_provenance(arc_dir)
+    provenance['complete'] = True
+    bigbang.mailman.update_provenance(arc_dir, provenance)
+

--- a/bin/collect_mail.py
+++ b/bin/collect_mail.py
@@ -6,7 +6,7 @@ import argparse
 from argparse import RawTextHelpFormatter
 
 parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description=r"""
-Collects files from public Mailman archives.
+Collects files from public mailing list archives.
 
 Please include either a url of a mailman web archive or the path to a file with
 a linebreak-separated list of such urls.
@@ -26,23 +26,29 @@ parser.add_argument('-f', type=str, help='Path of a file with linebreak-seperate
 
 parser.add_argument('--archives', type=str, help='Path to a specified directory for storing downloaded mail archives')
 
+parser.add_argument('--notes', type=str, help='Notes to record regarding provenance')
+
 args = parser.parse_args()
 
 logging.basicConfig(level=logging.DEBUG)
 
 
 def main(args):
+    notes = None
+    if args.notes:
+        notes = args.notes
+
     if args.u:
         if args.archives:
-            mailman.collect_from_url(args.u, archive_dir=args.archives)
+            mailman.collect_from_url(args.u, archive_dir=args.archives, notes=notes)
         else:
-            mailman.collect_from_url(args.u)
+            mailman.collect_from_url(args.u, notes=notes)
         sys.exit()
     elif args.f:
         if args.archives:
-            mailman.collect_from_file(args.f, archive_dir=args.archives)
+            mailman.collect_from_file(args.f, archive_dir=args.archives, notes=notes)
         else:
-            mailman.collect_from_file(args.f)
+            mailman.collect_from_file(args.f, notes=notes)
 
 if __name__ == "__main__":
     main(args)


### PR DESCRIPTION
Adds feature noted in #283 

Changes crawl functionality in `mailman.py`, `w3crawl.py` and the `collect_mail` script to add a provenance metadata file to each folder of mailing list archives downloaded.

Adds a command-line option to add a note to each provenance file.

Slightly improves error handling and a couple docstrings.