### PR TITLE
fix to conda install instructions -- specify Python 2.7, see #226

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run the following commands:
 
 ```bash
 git clone https://github.com/nllz/bigbang.git
-conda create -n bigbang python
+conda create -n bigbang python=2.7
 cd bigbang
 bash conda-setup.sh
 ```


### PR DESCRIPTION
Conda instructions need to specify the Python version, since the Conda default is now Python 3