### PR TITLE
raise MissingDataException when an Archive has no data, resolve #246

### DIFF
--- a/bigbang/archive.py
+++ b/bigbang/archive.py
@@ -56,8 +56,8 @@ class Archive(object):
         try:
             self.data['Date'] = pd.to_datetime(self.data['Date'], errors='coerce', infer_datetime_format=True, utc=True)
         except:
+            #TODO: writing a CSV file was for debugging purposes, should be removed
             out_path = 'datetime-exception.csv'
-
             with open(out_path, 'w') as f:
                 self.data.to_csv(f, encoding='utf-8')
             
@@ -105,7 +105,9 @@ class Archive(object):
             self.data.sort_values(by='Date', inplace=True)
         except:
             logging.error('Error while sorting, maybe timezone issues?', exc_info=True)
-
+        
+        if self.data.empty:
+            raise mailman.MissingDataException('Archive after initial processing is empty. Was data collected properly?')
 
     def resolve_entities(self,inplace=True):
         if self.entities is None:

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,6 +13,7 @@
 repo_path : "archives/sample-git-repos/"
 mail_path : "archives/"
 urls_path : "examples/"
+test_data_path: "tests/data/"
 
 
 # REGEX

--- a/tests/bigbang_tests.py
+++ b/tests/bigbang_tests.py
@@ -121,10 +121,8 @@ def test_labeled_blockmodel():
 
 def test_empty_list_compute_activity_issue_246():
     test_df_csv_path = os.path.join(CONFIG.test_data_path, 'empty-archive-df.csv')
-    df = pd.DataFrame.from_csv(path=test_df_csv_path)
+    df = pd.read_csv(test_df_csv_path)
 
     with assert_raises(mailman.MissingDataException):
         empty_archive = archive.Archive(df)
         activity = empty_archive.get_activity()
-
-    assert True, "activity computation on empty df without MissingDataException"

--- a/tests/bigbang_tests.py
+++ b/tests/bigbang_tests.py
@@ -122,6 +122,9 @@ def test_labeled_blockmodel():
 def test_empty_list_compute_activity_issue_246():
     test_df_csv_path = os.path.join(CONFIG.test_data_path, 'empty-archive-df.csv')
     df = pd.DataFrame.from_csv(path=test_df_csv_path)
-    activity = archive.Archive(df).get_activity()
 
-    assert True, "activity computation crashed on empty df"
+    with assert_raises(mailman.MissingDataException):
+        empty_archive = archive.Archive(df)
+        activity = empty_archive.get_activity()
+
+    assert True, "activity computation on empty df without MissingDataException"

--- a/tests/bigbang_tests.py
+++ b/tests/bigbang_tests.py
@@ -8,6 +8,8 @@ import bigbang.utils as utils
 import mailbox
 import os
 import networkx as nx
+import pandas as pd
+from config.config import CONFIG
 
 test_txt = ""
 
@@ -116,3 +118,10 @@ def test_labeled_blockmodel():
 
     assert list(bg.edges()) == [('A','B')], \
         "Incorrected edges in labeled blockmodel"
+
+def test_empty_list_compute_activity_issue_246():
+    test_df_csv_path = os.path.join(CONFIG.test_data_path, 'empty-archive-df.csv')
+    df = pd.DataFrame.from_csv(path=test_df_csv_path)
+    activity = archive.Archive(df).get_activity()
+
+    assert True, "activity computation crashed on empty df"

--- a/tests/data/empty-archive-df.csv
+++ b/tests/data/empty-archive-df.csv
@@ -1,0 +1,1 @@
+Message-ID,From,Subject,Date,In-Reply-To,References,Body


### PR DESCRIPTION
Resolve #246 by detecting when the data for an archive is empty and throwing a MissingDataException, rather than waiting for a later unexplained exception (in this case, a ValueError when trying to generate a new range for an updated index during activity computation).

This also creates a regression test which confirms this new behavior.