### PR TITLE
Issue287 - created description of lists in examples/url_collections

### DIFF
--- a/examples/url_collections/lists_description.md
+++ b/examples/url_collections/lists_description.md
@@ -1,0 +1,26 @@
+# This is a description of the following URL collections:
+
+## a collection of Code for America git repositories
+cfa_urls.txt
+
+## a collection of Code for America mailing lists
+codeforamerica_urls.txt
+
+## a collection of git repositories of the social science data lab at UC Berkeley
+dlab-berkeley_urls.txt
+
+## a collection of Open edX platform git repositories
+edX_urls.txt
+
+## a collection of git repositories of the following projects: django, scipy, npm and sbenthall's branch of BigBang
+git_urls.txt
+
+## a collection of git repositories of the Glass Beads Labs for Social Measurement at UC Berkeley
+glass-bead-labs_urls.txt
+
+## a collection of all public ICANN mailing lists per March 2018
+mm.icann.org.txt
+
+## a collection of all public IETF mailing lists per March 2018
+mm.ietf.org.txt
+


### PR DESCRIPTION
In accordance with #287 I made a file with the descriptions of the lists in examples/url_collections