### PR TITLE
added cython because of issues install dependencies

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,3 +1,4 @@
+cython
 beautifulsoup4
 coverage
 matplotlib


### PR DESCRIPTION
I reinstalled the whole bigbang package on Debian Stable and encountered dependency issues when running $ bash conda-setup.sh. Should be resolved with this addition to conda-requirements.txt.