### PR TITLE
set python version in conda installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run the following commands:
 ```bash
 
 git clone https://github.com/datactive/bigbang.git
-conda create -n bigbang python
+conda create -n bigbang python=2.7
 cd bigbang
 bash conda-setup.sh
 source activate bigbang


### PR DESCRIPTION
I did a recent re-install and found at that in the new conda version on needs to set the python version else it defaults to python 3.