### PR TITLE
some mailman.py tests

### DIFF
--- a/tests/bigbang_tests.py
+++ b/tests/bigbang_tests.py
@@ -143,3 +143,30 @@ def test_empty_list_compute_activity_issue_246():
     with assert_raises(mailman.MissingDataException):
         empty_archive = archive.Archive(df)
         activity = empty_archive.get_activity()
+
+def test_mailman_normalizer():
+    browse_url = 'https://mailarchive.ietf.org/arch/browse/ietf/'
+    search_url = 'https://mailarchive.ietf.org/arch/search/?email_list=ietf'
+    random_url = 'http://example.com'
+
+    better_url = 'https://www.ietf.org/mail-archive/text/ietf/'
+
+    assert mailman.normalize_archives_url(browse_url) == better_url, "failed to normalize"
+    assert mailman.normalize_archives_url(search_url) == better_url, "failed to normalize"
+    assert mailman.normalize_archives_url(random_url) == random_url, "should not have changed other url"
+
+def test_mailman_list_name():
+    ietf_archive_url = 'https://www.ietf.org/mail-archive/text/ietf/'
+    w3c_archive_url = 'https://lists.w3.org/Archives/Public/public-privacy/'
+    random_url = 'http://example.com'
+
+    assert mailman.get_list_name(ietf_archive_url) == 'ietf', "failed to grab ietf list name"
+    assert mailman.get_list_name(w3c_archive_url) == 'public-privacy', "failed to grab w3c list name"
+    assert mailman.get_list_name(random_url) == random_url, "should not have changed other url"
+
+def test_activity_summary():
+    list_url = 'https://lists.w3.org/Archives/Public/test-activity-summary/'
+    activity_frame = mailman.open_activity_summary(list_url, archive_dir=CONFIG.test_data_path)
+
+    assert str(type(activity_frame)) == "<class 'pandas.core.frame.DataFrame'>", "not a DataFrame?"
+    assert len(activity_frame.columns) == 1, "activity summary should have one column"

--- a/tests/data/test-activity-summary/perpass-activity.csv
+++ b/tests/data/test-activity-summary/perpass-activity.csv
@@ -1,0 +1,262 @@
+From,Message Count
+"""Adrian Farrel"" <adrian@olddog.co.uk>",3.0
+"""Andreas Kuckartz"" <a.kuckartz@ping.de>",8.0
+"""Bernie Volz (volz)"" <volz@cisco.com>",1.0
+"""Carl S. Gutekunst"" <cgutekunst@sonicwall.com>",3.0
+"""Christian Huitema "" <huitema@huitema.net>",1.0
+"""Christian Huitema"" <huitema@huitema.net>",39.0
+"""Cullen Jennings (fluffy)"" <fluffy@cisco.com>",3.0
+"""Dickson, Brian"" <bdickson@verisign.com>",1.0
+"""Eduardo A. =?utf-8?b?U3XDoXJleg==?="" <esuarez@fcaglp.fcaglp.unlp.edu.ar>",1.0
+"""Eggert, Lars"" <lars@netapp.com>",3.0
+"""Fred Baker (fred)"" <fred@cisco.com>",10.0
+"""Giovane C. M. Moura"" <giovane.moura@sidn.nl>",1.0
+"""Hannes Tschofenig"" <Hannes.Tschofenig@gmx.net>",1.0
+"""Hosnieh Rafiee"" <ietf@rozanak.com>",9.0
+"""Jiankang Yao"" <yaojk@cnnic.cn>",2.0
+"""Joe St Sauver"" <joe@oregon.uoregon.edu>",7.0
+"""John Levine"" <johnl@taugh.com>",5.0
+"""John R Levine"" <johnl@taugh.com>",5.0
+"""Learmonth, Iain Ross"" <iain.learmonth.09@aberdeen.ac.uk>",12.0
+"""Matt Larson via RT"" <ietf-action@ietf.org>",1.0
+"""Matthijs R. Koot"" <matthijs@koot.biz>",1.0
+"""Moriarty, Kathleen"" <kathleen.moriarty@emc.com>",17.0
+"""Nicolas Mailhot"" <nicolas.mailhot@laposte.net>",2.0
+"""Olle E. Johansson"" <oej@edvina.net>",4.0
+"""Orit Levin (LCA)"" <oritl@microsoft.com>",3.0
+"""Paul Bakker"" <p.j.bakker@offspark.com>",1.0
+"""Peterson, Jon"" <jon.peterson@neustar.biz>",5.0
+"""Poul-Henning Kamp"" <phk@phk.freebsd.dk>",1.0
+"""Richard Shockey"" <richard@shockey.us>",10.0
+"""Rose, Scott"" <scott.rose@nist.gov>",1.0
+"""Roy T. Fielding"" <fielding@gbiv.com>",1.0
+"""Russ White"" <russw@riw.us>",5.0
+"""Scharf, Michael (Michael)"" <michael.scharf@alcatel-lucent.com>",1.0
+"""Scott O. Bradner"" <sob@sobco.com>",1.0
+"""Simo Fhom, Hervais-Clemence"" <hervais.simo@sit.fraunhofer.de>",1.0
+"""Songhaibin (A)"" <haibin.song@huawei.com>",1.0
+"""Steven M. Bellovin"" <smb@cs.columbia.edu>",2.0
+"""Wiley, Glen"" <gwiley@verisign.com>",4.0
+"""Zuniga, Juan Carlos"" <JuanCarlos.Zuniga@InterDigital.com>",2.0
+"""d.nix"" <d.nix@comcast.net>",3.0
+<Kent_Landfield@McAfee.com>,1.0
+<l.wood@surrey.ac.uk>,3.0
+=?ISO-8859-15?Q?Matth=E4us_Wander?= <matthaeus.wander@uni-due.de>,1.0
+=?UTF-8?B?V2lsbGlhbSBDaGFuICjpmYjmmbrmmIwp?= <willchan@chromium.org>,1.0
+=?UTF-8?Q?Rapha=C3=ABl_Jacquot?= <sxpert@sxpert.org>,1.0
+=?utf-8?Q?Ond=C5=99ej_Sur=C3=BD?= <ondrej.sury@nic.cz>,1.0
+=JeffH <Jeff.Hodges@KingsMountain.com>,7.0
+Adam Caudill <adam@adamcaudill.com>,2.0
+Adam Langley <agl@google.com>,1.0
+Al Clark <alexander.m.clark@gmail.com>,1.0
+Albert Lunde <atlunde@panix.com>,5.0
+Alex Elsayed <eternaleye@gmail.com>,1.0
+Alexey Melnikov <alexey.melnikov@isode.com>,2.0
+Alfredo Pironti <alfredo@pironti.eu>,1.0
+Alissa Cooper <acooper@cdt.org>,6.0
+Alissa Cooper <alissa@cooperw.in>,1.0
+Allison Mankin <allison.mankin@gmail.com>,1.0
+Andrea Bittau <bittau@cs.stanford.edu>,2.0
+Andrew Sullivan <ajs@anvilwalrusden.com>,3.0
+Andy Wilson <andrewgwilson@gmail.com>,1.0
+Avri Doria <avri@acm.org>,11.0
+Avri Doria <doriavr@gmail.com>,1.0
+Aziz Mohaisen <a.mohaisen@gmail.com>,2.0
+Ben Laurie <benl@google.com>,36.0
+Benjamin Kaduk <kaduk@MIT.EDU>,2.0
+Benoit Claise <bclaise@cisco.com>,3.0
+Bjoern Hoehrmann <derhoermi@gmx.net>,24.0
+Bob Harold <rharolde@umich.edu>,1.0
+Brian E Carpenter <brian.e.carpenter@gmail.com>,31.0
+Brian Rosen <br@brianrosen.net>,3.0
+Brian Trammell <ietf@trammell.ch>,6.0
+Brian Trammell <trammell@tik.ee.ethz.ch>,23.0
+Bruce Perens <bruce@perens.com>,31.0
+Carl Wallace <carl@redhoundsoftware.com>,5.0
+Christian Grothoff <christian@grothoff.org>,1.0
+Christian Grothoff <grothoff@gnunet.org>,1.0
+Christian Huitema <huitema@huitema.net>,1.0
+Christoph Zeiher <chris@tcij.org>,1.0
+Chuck Davin <chuck@eesst.org>,2.0
+Colin Perkins <csp@csperkins.org>,1.0
+Cullen Jennings <fluffy@iii.ca>,5.0
+Dan Schlitt <schlitt@theworld.com>,1.0
+Dan Wing <dwing@cisco.com>,2.0
+Dan York <york@isoc.org>,10.0
+Daniel Kahn Gillmor <dkg@fifthhorseman.net>,1.0
+DataPacRat <datapacrat@gmail.com>,11.0
+Dave Crocker <dcrocker@bbiw.net>,5.0
+Dave Crocker <dhc@dcrocker.net>,48.0
+Dave Thaler <dthaler@microsoft.com>,2.0
+David Conrad <drc@virtualized.org>,2.0
+David Lloyd-Jones <david.lloydjones@gmail.com>,3.0
+David Morris <dwm@xpasc.com>,1.0
+David Singer <singer@apple.com>,2.0
+Dean Willis <dean.willis@softarmor.com>,30.0
+Derek Fawcus <dfawcus+lists-perpass@employees.org>,4.0
+Don Blumenthal <dblumenthal@pir.org>,1.0
+Douglas Otis <doug.mtview@gmail.com>,18.0
+Edward Lopez <elopez@fortinet.com>,2.0
+Eitan Adler <lists@eitanadler.com>,2.0
+Elijah Sparrow <elijah@bitmask.net>,2.0
+Elijah Sparrow <elijah@leap.se>,2.0
+Eliot Lear <lear@cisco.com>,25.0
+Elwyn Davies <davieseb@scss.tcd.ie>,3.0
+Eric Burger <eburger@cs.georgetown.edu>,1.0
+Eric Burger <eburger@standardstrack.com>,10.0
+Eric Rescorla <ekr@rtfm.com>,1.0
+Fernando Gont <fgont@si6networks.com>,5.0
+Francis Dupont <Francis.Dupont@fdupont.fr>,1.0
+George Michaelson <ggm@algebras.org>,6.0
+Hadriel Kaplan <hadriel.kaplan@oracle.com>,1.0
+Hagen Paul Pfeifer <hagen@jauu.net>,1.0
+Hannes Tschofenig <hannes.tschofenig@gmx.net>,46.0
+Harry Halpin <hhalpin@w3.org>,5.0
+Hugo Connery <hmco@env.dtu.dk>,1.0
+Hugo Maxwell Connery <hmco@env.dtu.dk>,9.0
+IETF Secretariat <ietf-secretariat@ietf.org>,1.0
+JOSEFSSON Erik <erik.josefsson@europarl.europa.eu>,5.0
+Jacob Appelbaum <jacob@appelbaum.net>,24.0
+James Cloos <cloos@jhcloos.com>,2.0
+Jari Arkko <jari.arkko@piuha.net>,3.0
+Jean-Michel Combes <jeanmichel.combes@gmail.com>,1.0
+Jim Fenton <fenton@bluepopcorn.net>,11.0
+John Heidemann <johnh@isi.edu>,1.0
+John Wroclawski <jtw@csail.mit.edu>,1.0
+John-Mark Gurney <jmg@funkthat.com>,7.0
+Jon Callas <jon.callas@icloud.com>,1.0
+Jon Callas <joncallas@icloud.com>,2.0
+Joseph Lorenzo Hall <joe@cdt.org>,24.0
+Josh Howlett <Josh.Howlett@ja.net>,3.0
+Karen ODonoghue <odonoghue@isoc.org>,2.0
+Karl Dubost <karl@la-grange.net>,2.0
+Karl Malbrain <karl@petzent.com>,15.0
+Karl Malbrain <malbrain@yahoo.com>,21.0
+Kartoss <kartoss@krautfleet.net>,1.0
+Kathleen Moriarty <kathleen.moriarty.ietf@gmail.com>,8.0
+Klaas Wierenga <klaas@wierenga.net>,1.0
+Leif Johansson <leifj@mnt.se>,17.0
+Leo Vegoda <leo@vegoda.org>,4.0
+Linus Nordberg <linus@nordberg.se>,6.0
+Lucy Lynch <llynch@civil-tongue.net>,4.0
+Magnus Westerlund <magnus.westerlund@ericsson.com>,1.0
+Marc Blanchet <marc.blanchet@viagenie.ca>,1.0
+Marc Petit-Huguenin <marc@petit-huguenin.org>,2.0
+Mark Atwood <me@mark.atwood.name>,3.0
+Mark Handley <m.handley@cs.ucl.ac.uk>,1.0
+Mark Handley <mark@handley.org.uk>,7.0
+Mark Nottingham <mnot@mnot.net>,1.0
+Mark Townsley <mark@townsley.net>,1.0
+Marsh Ray <maray@microsoft.com>,1.0
+Martin Millnert <martin@millnert.se>,6.0
+Martin Thomson <martin.thomson@gmail.com>,6.0
+Mathieu Cunche <mathieu.cunche@inria.fr>,2.0
+Melinda Shore <melinda.shore@gmail.com>,7.0
+Merike Kaeo <merike@doubleshotsecurity.com>,3.0
+Michael Richardson <mcr+ietf@sandelman.ca>,20.0
+Michael Richardson <mcr@sandelman.ca>,2.0
+Michiel Leenaars <michiel.ml@nlnet.nl>,2.0
+Mike Demmers <mdietf@demmers.org>,13.0
+Mike Liebhold <mnl@well.com>,7.0
+Moritz Bartl <moritz@headstrong.de>,2.0
+Nicholas Weaver <nweaver@ICSI.Berkeley.EDU>,10.0
+Nicholas Weaver <nweaver@icsi.berkeley.edu>,22.0
+Nick Doty <npdoty@ischool.berkeley.edu>,2.0
+Nick Mathewson <nickm@torproject.org>,5.0
+Nick Thomas <nick@lupine.me.uk>,4.0
+Nikos Mavrogiannopoulos <nmav@gnutls.org>,1.0
+Noel David Torres =?ISO-8859-1?Q?Ta=F1o?= <envite@rolamasao.org>,1.0
+Noel Torres <envite@rolamasao.org>,6.0
+Norbert Bollow <nb@bollow.ch>,4.0
+Oliver Gasser <gasser@net.in.tum.de>,1.0
+Patrick McManus <pmcmanus@mozilla.com>,3.0
+Patrick Pelletier <code@funwithsoftware.org>,8.0
+Paul Ferguson <fergdawgster@mykolab.com>,12.0
+Paul Hoffman <paul.hoffman@gmail.com>,8.0
+Paul Kyzivat <pkyzivat@alum.mit.edu>,6.0
+Paul Lambert <paul@marvell.com>,12.0
+Paul Vixie <paul@redbarn.org>,4.0
+Paul Wouters <paul@cypherpunks.ca>,17.0
+Paul Wouters <paul@nohats.ca>,9.0
+Peter Gutmann <pgut001@cs.auckland.ac.nz>,3.0
+Peter Lawler <perpass@bleeter.id.au>,4.0
+Peter Saint-Andre - Filament <peter@filament.com>,1.0
+Peter Saint-Andre <stpeter@stpeter.im>,11.0
+Phil Karn <karn@philkarn.net>,1.0
+Phillip Hallam-Baker <hallam@gmail.com>,123.0
+Phillip Hallam-Baker <ietf@hallambaker.com>,2.0
+Pranesh Prakash <pranesh@cis-india.org>,6.0
+Ralf Skyper Kaiser <skyper@thc.org>,6.0
+Randy Bush <randy@psg.com>,25.0
+Rene Struik <rstruik.ext@gmail.com>,1.0
+Richard Barnes <rlb@ipv.sx>,25.0
+Richard Guy Briggs <rgb@tricolour.net>,1.0
+Rob Stradling <rob.stradling@comodo.com>,2.0
+Robert Story <rstory@tislabs.com>,2.0
+Robin Wilton <wilton@isoc.org>,49.0
+Ross Schulman <ross@rbs.io>,1.0
+Ross Schulman <rschulman@gmail.com>,1.0
+Ross Snider <ross.snider@gmail.com>,1.0
+Russ Housley <housley@vigilsec.com>,8.0
+Russ Mundy <mundy@tislabs.com>,1.0
+Ryan Hurst <ryan.hurst@globalsign.com>,1.0
+S Moonesamy <sm+ietf@elandsys.com>,5.0
+SM <sm@resistor.net>,26.0
+Sam Hartman <hartmans-ietf@mit.edu>,1.0
+Scott Brim <scott.brim@gmail.com>,40.0
+Sean Turner <TurnerS@ieca.com>,3.0
+Seda Gurses <seda@nyu.edu>,1.0
+Seun Ojedeji <seun.ojedeji@gmail.com>,2.0
+Simon Josefsson <simon@josefsson.org>,9.0
+Spencer Dawkins <spencerdawkins.ietf@gmail.com>,1.0
+Spencer Dawkins at IETF <spencerdawkins.ietf@gmail.com>,2.0
+Stefan Winter <stefan.winter@restena.lu>,8.0
+Stephane Bortzmeyer <bortzmeyer@nic.fr>,58.0
+Stephen Farrell <stephen.farrell@cs.tcd.ie>,231.0
+Stephen Kent <kent@bbn.com>,75.0
+Steve Sarbot <ssarbot@yahoo.com>,1.0
+Suhas Nandakumar <suhasietf@gmail.com>,2.0
+Ted Hardie <ted.ietf@gmail.com>,14.0
+Ted Lemon <Ted.Lemon@nominum.com>,3.0
+Ted Lemon <mellon@fugue.com>,39.0
+Ted Lemon <ted.lemon@nominum.com>,4.0
+Theodore Ts'o <tytso@mit.edu>,9.0
+Thorsten Strufe <strufe.pub@googlemail.com>,2.0
+Tim Bray <tbray@textuality.com>,15.0
+Tim Chown <Tim.Chown@jisc.ac.uk>,1.0
+Tim Wicinski <tjw.ietf@gmail.com>,2.0
+Tobias Gondrom <tobias.gondrom@gondrom.org>,1.0
+Tony Finch <dot@dotat.at>,2.0
+Tony Hansen <tony@att.com>,1.0
+Tony Rutkowski <rutkowski.tony@gmail.com>,35.0
+Trevor Freeman <trevor.freeman99@icloud.com>,2.0
+Trevor Freeman <trevorf@exchange.microsoft.com>,9.0
+Trevor Perrin <trevp@trevp.net>,1.0
+Vidya Narayanan <vn@google.com>,4.0
+Walter Pienciak <w.pienciak@ieee.org>,1.0
+Warren Kumari <warren@kumari.net>,11.0
+Watson Ladd <watsonbladd@gmail.com>,17.0
+Wendy Seltzer <wseltzer@w3.org>,1.0
+Xiaoyong Wu <X.Wu@F5.com>,1.0
+Yakov Shafranovich <yakov-ietf@shaftek.org>,6.0
+Yakov Shafranovich <yakov@noom.com>,2.0
+Yakov Shafranovich <yakov@shaftek.biz>,3.0
+Yaron Sheffer <yaronf.ietf@gmail.com>,9.0
+Yoav Nir <ynir@checkpoint.com>,22.0
+Zi Hu <zihu@usc.edu>,1.0
+avri <avri@acm.org>,1.0
+carlo von lynX <lynX@youfixtheinternet.psyced.org>,2.0
+dan@geer.org,7.0
+heinerhummel@aol.com,2.0
+home <sxpert@sxpert.org>,1.0
+ietf <paf@frobbit.se>,1.0
+joel jaeggli <joelja@bogus.com>,11.0
+karl m <malbrain@yahoo.com>,1.0
+lynX@youfixtheinternet.psyced.org,1.0
+manning bill <bmanning@isi.edu>,11.0
+mrex@sap.com (Martin Rex),2.0
+ned+perpass@mrochek.com,20.0
+pindar wong <pindar.wong@gmail.com>,1.0
+stephen.farrell@cs.tcd.ie,1.0
+tytso@mit.edu,2.0
+wilton@isoc.org,1.0


### PR DESCRIPTION
Adds tests to cover:

* list name and URL normalization
* activity summary opening
* provenance creation, update, access

... in `mailman.py`. Still needs coverage of the main load data paths, but those are currently pretty closely tied into actual data and network access, which makes them tricky to test in a way that doesn't add time/complexity to the test suite.