### PR TITLE
functions for parsing email names; config fixes

### DIFF
--- a/bigbang/parse.py
+++ b/bigbang/parse.py
@@ -48,6 +48,65 @@ def clean_from(m_from):
 
     return cleaned
 
+def normalize_email_address(address):
+    """
+    Takes a valid email address and returns a normalized one, for matching purposes.
+    """
+    # TODO: drop the + labeling
+    return address.lower()
+
+def clean_name(name):
+    """
+    Clean just the name portion from email.utils.parseaddr.
+
+    Returns None if the name portion is missing anything name-like. Otherwise, returns the cleaned name.
+    """
+
+    # we see these specific strings due to parsing issues in email somewhere
+    name = name.replace('unknown charset', ' ') 
+    name = name.replace('wrong string', ' ')
+    name = name.replace('_', ' ')
+
+    # these are stop characters we can just delete
+    stop_characters = unicode('"<>\\()/:?%!+\'@')
+    stop_characters_map = dict((ord(char), None) for char in stop_characters)
+
+    name = unicode(name, 'utf-8', 'ignore').translate(stop_characters_map)
+
+    # do we need to also catch email archives that use anti-spam measures?
+    # like: .replace(' at ','@')
+
+    # TODO: decode or collapse rfc2231 encodings, like '=?utf-8?q?carlos_gonz=c3=a1lez-cadenas?=' ?
+
+    name = name.strip() # remove leading and trailing whitespace
+
+    if len(name) > 0:
+        return name
+    else:
+        return None
+
+def tokenize_name(clean_name):
+    """
+    Create a tokenized version of a name, good for comparison and sorting for entity resolution.
+
+    Takes a Unicode name already cleaned of most punctuation and spurious characters, hopefully.
+    """
+
+    # make lower case, remove "." and ",", tokenize and lexicographically sort the tokens, join by spaces, return as a string
+
+    stop_characters = unicode('".,')
+    stop_characters_map = dict((ord(char), None) for char in stop_characters)
+    name = clean_name.translate(stop_characters_map)
+
+    tokens = name.lower().split() # splits on whitespace
+    
+    if len(tokens) == 0:
+        return None
+
+    tokenized_name = ' '.join(sorted(tokens)) 
+    
+    return tokenized_name
+
 def guess_first_name(cleaned_from):
     """
     Attempt to extract a person's first name from the cleaned version of their name

--- a/config/config.py
+++ b/config/config.py
@@ -1,11 +1,9 @@
 import yaml
 import os
 
-base_loc = os.path.dirname(os.path.realpath(__file__))
-last_index = base_loc.rfind("/")
-base_loc = base_loc[0:last_index] + "/"
-
-config_filepath = base_loc + "config/config.yml"
+file_path = os.path.dirname(os.path.realpath(__file__))
+base_loc = os.path.abspath(os.path.join(file_path, os.pardir)) # parent directory of config directory
+config_filepath = os.path.join(base_loc, "config", "config.yml")
 stream = open(config_filepath, "r")
 dictionary = yaml.load(stream)
 
@@ -17,7 +15,7 @@ class Config(object):
 		if query in self.CONFIG:
 			ans = self.CONFIG[query];
 			if "path" in query:
-				ans = base_loc + ans
+				ans = os.path.join(base_loc, ans)
 			return ans
 		else:
 			return None

--- a/tests/bigbang_tests.py
+++ b/tests/bigbang_tests.py
@@ -10,6 +10,8 @@ import mailbox
 import os
 import networkx as nx
 import pandas as pd
+import email
+import logging
 
 from config.config import CONFIG
 
@@ -195,3 +197,21 @@ def test_provenance():
     mailman.update_provenance(TEMP_DIR, provenance)
     provenance_next = mailman.access_provenance(TEMP_DIR)
     assert provenance_next['notes'] == 'modified provenance', "confirm modified provenance"
+
+def test_name_email_parsing():
+    from_header = 'John_Doe (?) <John.Doe@example.com>'
+    (raw_name, raw_email) = email.utils.parseaddr(from_header)
+    normalized_email = parse.normalize_email_address(raw_email)
+    assert normalized_email == 'john.doe@example.com', "normalized email case incorrect"
+
+    clean_name = parse.clean_name(raw_name)
+    assert clean_name == 'John Doe', "name not fully cleaned"
+
+    empty_name = parse.clean_name(' ')
+    assert empty_name is None, "empty name not cleaned to None"
+
+    tokenized_name = parse.tokenize_name(clean_name)
+    assert tokenized_name == 'doe john', "name not properly normalized and tokenized"
+
+    empty_tokenized_name = parse.tokenize_name(unicode('   '))
+    assert empty_name is None, "empty name not tokenized to None"


### PR DESCRIPTION
This PR creates new methods in `bigbang.parse` for cleaning and tokenizing names and email addresses, which is useful for entity resolution (and is used in the ietf-participation notebooks). Tests for those new functions are also included.

This also addresses #357 so that the `config` module works in a more platform-agnostic way.

(Apologies for not cleanly separating into two PRs, I got git-confused.)