### PR TITLE
remove extra call from open_list_archives that created an infinite recursion

### DIFF
--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -413,11 +413,6 @@ def open_list_archives(
 
     messages = None
 
-    if "http" in url:
-        collect_from_url(url, notes=None)
-        list_name = get_list_name(url)
-        archive_dir = archive_directory(CONFIG.mail_path, list_name)
-
     if mbox and (os.path.isfile(os.path.join(archive_dir, url))):
         # treat string as the path to a file that is an mbox
         box = mailbox.mbox(os.path.join(archive_dir, url), create=False)


### PR DESCRIPTION
addresses #425

still needed: better, non-unit tests for mailman.py so that regressions will be caught automatically

This change got added in during the formatting changes, but it affects the actual flow of collecting mail and opening archives, in a way that introduced an infinite loop.