### PR TITLE
Handle message in LISTSERV archive with no date

### DIFF
--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -96,7 +96,7 @@ class ListservMessage:
         "fromaddr": None,
         "toname": None,
         "toaddr": None,
-        "date": "Mon, 11 Jan 1111 11:11:11",
+        "date": None,
         "contenttype": None,
     }
 
@@ -367,8 +367,8 @@ class ListservMessage:
         date: Union[str, None],
         from_address: Union[str, None],
     ) -> str:
-        #if date is None:
-        #    date = 'Wed Jan 11 11:11:11 1111'
+        if date is None:
+            date = 'None'
         message_id = (".").join([date, from_address])
         # remove special characters
         message_id = re.sub(r"[^a-zA-Z0-9]+", "", message_id)

--- a/tests/data/3GPP/3GPP_TSG_SA_ITUT_AHG/3GPP_TSG_SA_ITUT_AHG.LOG1703C
+++ b/tests/data/3GPP/3GPP_TSG_SA_ITUT_AHG/3GPP_TSG_SA_ITUT_AHG.LOG1703C
@@ -1,5 +1,4 @@
 =========================================================================
-Date:         Wed, 15 Mar 2017 15:13:05 +0000
 Reply-To:     Romano Giovanni <giovanni.romano@TELECOMITALIA.IT>
 From:         Romano Giovanni <giovanni.romano@TELECOMITALIA.IT>
 Subject:      R: How to proceed with ITUT-AH

--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -71,6 +71,27 @@ class TestListservList:
         assert "What do you think of the approach?\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
+    
+    def test__missing_date_in_message(self, mlist):
+        """
+        Test that when a message has no date show, a default value
+        """
+        msg = [
+            msg
+            for msg in mlist.messages
+            if msg.subject
+            == "R: How to proceed with ITUT-AH"
+        ][0]
+        assert msg.date == None
+        msg.to_mbox(filepath=f'{dir_temp}/msg_test.mbox')
+        file_temp_mbox = f"{dir_temp}/msg_test.mbox"
+        f = open(file_temp_mbox, "r")
+        lines = f.readlines()
+        print(lines)
+        assert len(lines) == 478
+        assert "Date: None'\n" in lines
+        f.close()
+        Path(file_temp_mbox).unlink()
 
 
 class TestListservArchive:

--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -87,7 +87,6 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/msg_test.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        print(lines)
         assert len(lines) == 478
         assert "Date: None'\n" in lines
         f.close()


### PR DESCRIPTION
This PR addresses issue #457.

It includes a new test in `tests/unit/test_listserv.py` to make sure this corner case is handled correctly.