### PR TITLE
Address issue 460

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ python-Levenshtein
 pytz>=2020.5
 pyzmq
 tornado
+tqdm
 requests>=2.25.1
 pyyaml
 common


### PR DESCRIPTION
This PR addresses issue #460.

Implements the following:
- changes the logger `filemode` from appending (`'a'`) to erasure of previous content and rewriting it (`'w'`)
- use `pathlib` to take care of folder structure instead of `os.mkdir`
- use tqcdm for visual feedback on messages scraping progress:
```
❯ python bin/collect_mail.py -f ../listserv.test.txt     
3GPP_TSG_RAN_ADHOC: 100%|##################################| 69/69 [02:04<00:00,  1.80s/it]
```