### PR TITLE
Solve issue 459

### DIFF
--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -25,10 +25,11 @@ from tqdm import tqdm
 
 from config.config import CONFIG
 
-project_directory = str(Path(os.path.abspath(__file__)).parent.parent)
+filepath_auth = CONFIG.config_path + "authentication.yaml"
+directory_project = str(Path(os.path.abspath(__file__)).parent.parent)
 
 logging.basicConfig(
-    filename=project_directory + "/listserv.log",
+    filename=directory_project + "/listserv.log",
     filemode="w",
     level=logging.INFO,
     format="%(asctime)s %(message)s",
@@ -1228,9 +1229,25 @@ class ListservArchive(object):
 def get_auth_session(
     url_login: str, username: str, password: str
 ) -> requests.Session:
-    """Create AuthSession"""
-    # ask user for login keys
-    username, password = get_login_from_terminal(username, password)
+    """
+    Create AuthSession.
+
+    There are three ways to create an AuthSession:
+        - parse username & password directly into method
+        - create a /bigbang/config/authentication.yaml file that contains keys
+        - type then into terminal when the method 'get_login_from_terminal'
+            is raised
+    """
+    if os.path.isfile(filepath_auth):
+        # read from /config/authentication.yaml
+        with open(filepath_auth, "r") as stream:
+            auth_key = yaml.safe_load(stream)
+        username = auth_key["username"]
+        password = auth_key["password"]
+    else:
+        # ask user for login keys
+        username, password = get_login_from_terminal(username, password)
+
     if username is None or password is None:
         # continue without authentication
         return None
@@ -1252,7 +1269,7 @@ def get_auth_session(
 def get_login_from_terminal(
     username: Union[str, None],
     password: Union[str, None],
-    file_auth: str = project_directory + "/config/authentication.yaml",
+    file_auth: str = directory_project + "/config/authentication.yaml",
 ) -> Tuple[Union[str, None]]:
     """
     Get login key from user during run time if 'username' and/or 'password' is 'None'.

--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -141,12 +141,19 @@ class ListservMessage:
     ) -> "ListservMessage":
         """
         Args:
+            list_name:
+            url:
+            fields:
+            url_login:
+            login:
+            session:
         """
         if session is None:
             session = get_auth_session(url_login, **login)
         soup = get_website_content(url, session=session)
         if soup == "RequestException":
-            return cls("RequestException", **cls.empty_header)
+            body = "RequestException"
+            header = cls.empty_header
         else:
             if fields in ["header", "total"]:
                 header = ListservMessage.get_header_from_html(soup)
@@ -156,7 +163,7 @@ class ListservMessage:
                 body = ListservMessage.get_body_from_html(list_name, url, soup)
             else:
                 body = None
-            return cls(body, **header)
+        return cls(body, **header)
 
     @classmethod
     def from_listserv_file(
@@ -640,7 +647,7 @@ class ListservList:
         session: Optional[dict] = None,
     ) -> List[ListservMessage]:
         """
-        Generator that yields all messages within a certain period
+        Generator that returns all messages within a certain period
         (e.g. January 2021, Week 5).
 
         Args:
@@ -1316,7 +1323,6 @@ def get_website_content(
             soup = BeautifulSoup(sauce.text, "html.parser")
         return soup
     except requests.exceptions.RequestException as e:
-        # TODO logger
         if "A2=" in url:
             # if URL of ListservMessage
             logger.info(f"{e} for {url}.")

--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -10,10 +10,10 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
-from urllib.parse import urlparse
 import warnings
 from pprint import pprint as pp
 from typing import Union
+from urllib.parse import urlparse
 
 import pandas as pd
 import yaml
@@ -29,11 +29,12 @@ txt_exp = re.compile(r'href="(\d\d\d\d-\w*\.txt)"')
 gz_exp = re.compile(r'href="(\d\d\d\d-\w*\.txt\.gz)"')
 ietf_ml_exp = re.compile(r'href="([\d-]+.mail)"')
 w3c_archives_exp = re.compile(r"lists\.w3\.org")
-tgpp_archives_exp = re.compile(r'list\.etsi\.org')
-ieee_archives_exp = re.compile(r'listserv\.ieee\.org')
+tgpp_archives_exp = re.compile(r"list\.etsi\.org")
+ieee_archives_exp = re.compile(r"listserv\.ieee\.org")
 
 mailing_list_path_expressions = [gz_exp, ietf_ml_exp, txt_exp]
 
+file_auth = CONFIG.config_path + "authentication.yaml"
 PROVENANCE_FILENAME = "provenance.yaml"
 
 
@@ -283,7 +284,9 @@ def update_provenance(directory, provenance):
 
 
 def collect_archive_from_url(
-        url: Union[list, str], archive_dir=CONFIG.mail_path, notes=None,
+    url: Union[list, str],
+    archive_dir=CONFIG.mail_path,
+    notes=None,
 ):
     """
     Collect archives (generally tar.gz) files from mailmain archive page.
@@ -302,20 +305,24 @@ def collect_archive_from_url(
     if w3c_archives_exp.search(url):
         return w3crawl.collect_from_url(url, archive_dir, notes=notes)
     elif tgpp_archives_exp.search(url):
+        with open(file_auth, "r") as stream:
+            auth_key = yaml.safe_load(stream)
         return listserv.ListservArchive.from_mailing_lists(
             name="3GPP",
             url_root=url_root,
             url_mailing_lists=urls,
-            login={'username': '...', 'password': '...'},
+            login=auth_key,
             only_mlist_urls=False,
             instant_save=True,
         )
     elif ieee_archives_exp.search(url):
+        with open(file_auth, "r") as stream:
+            auth_key = yaml.safe_load(stream)
         return listserv.ListservArchive.from_mailing_lists(
             name="IEEE",
             url_root=url_root,
             url_mailing_lists=urls,
-            login={'username': '...', 'password': '...'},
+            login=auth_key,
             only_mlist_urls=False,
             instant_save=True,
         )

--- a/bigbang/mailman.py
+++ b/bigbang/mailman.py
@@ -305,24 +305,18 @@ def collect_archive_from_url(
     if w3c_archives_exp.search(url):
         return w3crawl.collect_from_url(url, archive_dir, notes=notes)
     elif tgpp_archives_exp.search(url):
-        with open(file_auth, "r") as stream:
-            auth_key = yaml.safe_load(stream)
         return listserv.ListservArchive.from_mailing_lists(
             name="3GPP",
             url_root=url_root,
             url_mailing_lists=urls,
-            login=auth_key,
             only_mlist_urls=False,
             instant_save=True,
         )
     elif ieee_archives_exp.search(url):
-        with open(file_auth, "r") as stream:
-            auth_key = yaml.safe_load(stream)
         return listserv.ListservArchive.from_mailing_lists(
             name="IEEE",
             url_root=url_root,
             url_mailing_lists=urls,
-            login=auth_key,
             only_mlist_urls=False,
             instant_save=True,
         )


### PR DESCRIPTION
This PR addresses issue #459 .

Implements the following:
- Catching connection error which is raised due to `Max retries exceeded`
- solving it by waiting 30 sec before resuming

Tested on the following 3GPP mailing lists:
```
3GPP_TSG_GERAN_WG1: 100%|########################################| 1643/1643 [55:17<00:00,  2.02s/it]
3GPP_TSG_GERAN_WG2: 100%|########################################| 2457/2457 [1:22:02<00:00,  2.00s/it]
3GPP_TSG_RAN_WG4_CA: 100%|#######################################| 1654/1654 [49:56<00:00,  1.81s/it]
```
read as:
(3GPP list name): 100%|####################| (total nr. of messages)/ [(total time needed)<00:00,  (ave. time per message)]

