### PR TITLE
Make use of Python's email package for EmaiMessage types

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,4 @@
-[settings]
+[tool.isort]
 line_length = 88
 profile = "black"
 multi_line_output = 3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,10 @@
 repos:
--   repo: https://github.com/pycqa/isort
-    rev: 5.7.0
-    hooks:
-    - id: isort
-      args: ["--profile", "black", "--filter-files"]
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 21.5b1
     hooks:
     - id: black
       language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
     - id: flake8

--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -800,13 +800,21 @@ class ListservList:
             Path(filepath).unlink()
         mbox = mailbox.mbox(filepath)
         mbox.lock()
-        try:
-            for msg in self.messages:
+        for msg in self.messages:
+            try:
                 mbox.add(msg)
-            mbox.flush()
-        finally:
-            mbox.unlock()
+            except Exception as e:
+                logger.info(
+                    f'Add to .mbox error for {msg["Archived-At"]} because, {e}'
+                )
+        mbox.flush()
+        mbox.unlock()
         logger.info(f"The list {self.name} is saved at {filepath}.")
+
+        mbox.lock()
+        mbox.add(msg)
+        mbox.flush()
+        mbox.unlock()
 
 
 class ListservArchive(object):

--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -90,13 +90,13 @@ class ListservMessageParser(email.parser.Parser):
     """
 
     empty_header = {
-        "subject": "None",
-        "fromname": "None",
-        "fromaddr": "None",
-        "toname": "None",
-        "toaddr": "None",
-        "date": "None",
-        "contenttype": "None",
+        "subject": None,
+        "fromname": None,
+        "fromaddr": None,
+        "toname": None,
+        "toaddr": None,
+        "date": None,
+        "contenttype": None,
     }
 
     def __init__(
@@ -124,23 +124,26 @@ class ListservMessageParser(email.parser.Parser):
         contenttype: str,
     ) -> mboxMessage:
         msg = email.message.EmailMessage()
-        msg.set_content(body)
-        msg["Subject"] = subject
-        if (fromname != "None") and (fromaddr != "None"):
+        if body is not None:
+            msg.set_content(body)
+        if subject is not None:
+            msg["Subject"] = subject
+        if (fromname is not None) and (fromaddr is not None):
             msg["From"] = email.utils.formataddr((fromname, fromaddr))
-        if (toname != "None") and (toaddr != "None"):
+        if (toname is not None) and (toaddr is not None):
             msg["To"] = email.utils.formataddr((toname, toaddr))
-        if date != "None":
+        if date is not None:
             msg["Date"] = date
-        if contenttype != "None":
+        if contenttype is not None:
             msg.set_param("Content-Type", contenttype)
-        if (date != "None") and (fromaddr != "None"):
+        if (date is not None) and (fromaddr is not None):
             msg["Message-ID"] = self.create_message_id(date, fromaddr)
         mbox_msg = mboxMessage(msg)
-        mbox_msg.set_from(
-            from_=msg["From"],
-            time_=email.utils.parsedate(msg["Date"]),
-        )
+        if (date is not None) and (fromaddr is not None):
+            mbox_msg.set_from(
+                from_=msg["From"],
+                time_=email.utils.parsedate(msg["Date"]),
+            )
         mbox_msg.add_header("Archived-At", "<" + archived_at + ">")
         return mbox_msg
 
@@ -169,7 +172,7 @@ class ListservMessageParser(email.parser.Parser):
             if fields in ["body", "total"]:
                 body = self._get_body_from_html(list_name, url, soup)
             else:
-                body = "None"
+                body = None
         return self.create_email_message(url, body, **header)
 
     def from_listserv_file(
@@ -338,14 +341,14 @@ class ListservMessageParser(email.parser.Parser):
                 "toaddr": self.get_addr,
             },
             "date": {"date": self.get_date},
-            "content-type": {"contenttype": "None"},
+            "content-type": {"contenttype": None},
         }
         # run through format settings
         for key_old, value in formatting_header_conf.items():
             # if header contains field
             if key_old in header.keys():
                 for key_new, fct in formatting_header_conf[key_old].items():
-                    if fct == "None" or header[key_old] == "None":
+                    if fct is None or header[key_old] is None:
                         header[key_new] = header[key_old]
                     else:
                         header[key_new] = fct(header[key_old])
@@ -377,7 +380,7 @@ class ListservMessageParser(email.parser.Parser):
         return name.strip()
 
     @staticmethod
-    def get_addr(line: str) -> Union[str, None]:
+    def get_addr(line: str) -> str:
         # get string in between < and >
         email_addr = re.findall(r"\<(.*)\>", line)
         if email_addr:
@@ -397,8 +400,8 @@ class ListservMessageParser(email.parser.Parser):
 
     @staticmethod
     def create_message_id(
-        date: Union[str, None],
-        from_address: Union[str, None],
+        date: str,
+        from_address: str,
     ) -> str:
         message_id = (".").join([date, from_address])
         # remove special characters

--- a/bigbang/listserv.py
+++ b/bigbang/listserv.py
@@ -68,7 +68,6 @@ class ListservMessageParser(email.parser.Parser):
     Methods
     -------
     from_url
-    from_mbox
     from_listserv_file
     _get_header_from_html
     _get_body_from_html
@@ -122,9 +121,17 @@ class ListservMessageParser(email.parser.Parser):
         for key, value in header.items():
             if "content-type" == key.lower():
                 msg.set_param("Content-Type", value)
+            elif "mime-version" == key.lower():
+                msg.set_param("MIME-Version", value)
+            elif "content-transfer-encoding" == key.lower():
+                msg.set_param("Content-Transfer-Encoding", value)
             else:
                 msg[key] = value
-        if (msg["Date"] is not None) and (msg["From"] is not None):
+        if (
+            (msg["Message-ID"] is None)
+            and (msg["Date"] is not None)
+            and (msg["From"] is not None)
+        ):
             msg["Message-ID"] = archived_at.split("/")[-1]
         # convert to EmailMessage to mboxMessage
         mbox_msg = mboxMessage(msg)
@@ -775,7 +782,7 @@ class ListservList:
         """
         Place all message into a dictionary.
         """
-        return self.to_pandas_dataframe().to_dict("split")
+        return self.to_pandas_dataframe().to_dict()
 
     def to_mbox(self, dir_out: str, filename: Optional[str] = None):
         """
@@ -1139,7 +1146,7 @@ class ListservArchive(object):
         """
         Place all message into a dictionary.
         """
-        return self.to_pandas_dataframe().to_dict("split")
+        return self.to_pandas_dataframe().to_dict()
 
     def to_mbox(self, dir_out: str):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,21 +13,21 @@ jsonschema
 GitPython
 matplotlib>=3.3.3
 networkx>=2.5
-nltk
+nltk>=3.6.2
 numpy>=1.19.5
 pandas>=1.2.1
 python-dateutil
 python-Levenshtein
 pytz>=2020.5
-pyzmq
-tornado
-tqdm
+pyzmq>=22.0.3
+tornado>=6.1
+tqdm>=4.60.0
 requests>=2.25.1
 pyyaml
-common
+common>=0.1.2
 powerlaw
-validator_collection
-testfixtures
+validator_collection>=1.5.0
+testfixtures>=6.17.1
 git+https://github.com/gitpython-developers/GitPython.git
 
 # dev-dependencies

--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -47,8 +47,12 @@ class TestListservList:
 
     def test__first_message_header(self, msg):
         assert msg["From"] == "Stephen Hayes <stephen.hayes@ERICSSON.COM>"
-        assert msg["To"] == "Stephen Hayes <stephen.hayes@ERICSSON.COM>"
-        assert msg["Date"] == "Mon, 08 May 2017 10:47:41 -0000"
+        assert msg["Reply-To"] == "Stephen Hayes <stephen.hayes@ERICSSON.COM>"
+        assert (
+            msg["In-Reply-To"]
+            == "<3d326663df91466eaa406d2ac87bd662@PREWE13M05.ad.sprint.com>"
+        )
+        assert msg["Date"] == "Mon, 08 May 2017 10:47:41 +0000"
 
     def test__first_message_body(self, msg):
         assert msg.get_payload().split("\n")[3] == "Hi,"
@@ -56,7 +60,8 @@ class TestListservList:
 
     def test__to_dict(self, mlist):
         dic = mlist.to_dict()
-        assert len(list(dic.keys())) == 10
+        print(dic.keys())
+        assert len(list(dic.keys())) == 13
         assert len(dic[list(dic.keys())[0]]) == 25
 
     def test__to_mbox(self, mlist):
@@ -64,7 +69,7 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 48738
+        assert len(lines) == 48774
         assert "What do you think of the approach?\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
@@ -85,7 +90,7 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/msg_test.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 546
+        assert len(lines) == 547
         assert "Inviato: mercoled=3DEC 15 marzo 2017 16:06\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
@@ -118,20 +123,20 @@ class TestListservArchive:
             for msg in arch.lists[mtce_index].messages
             if msg["Subject"] == "test email - please ignore"
         ][0]
-        assert msg["From"] == "Jain Puneet <puneet.jain@INTEL.COM>"
-        assert msg["To"] == "Jain Puneet <puneet.jain@INTEL.COM>"
-        assert msg["Date"] == "Thu, 28 Feb 2013 18:58:18 -0000"
+        assert msg["From"] == '"Jain, Puneet" <puneet.jain@INTEL.COM>'
+        assert msg["Reply-To"] == '"Jain, Puneet" <puneet.jain@INTEL.COM>'
+        assert msg["Date"] == "Thu, 28 Feb 2013 18:58:18 +0000"
 
     def test__to_dict(self, arch):
         dic = arch.to_dict()
-        assert len(list(dic.keys())) == 11
-        assert len(dic[list(dic.keys())[0]]) == 82
+        assert len(list(dic.keys())) == 14
+        assert len(dic[list(dic.keys())[0]]) == 49
 
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
         file_dic = {
-            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 48738,
-            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 61496,
+            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 48774,
+            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 61569,
         }
         for filepath, line_nr in file_dic.items():
             assert Path(filepath).is_file()

--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -69,7 +69,7 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 48774
+        assert len(lines) == 49294
         assert "What do you think of the approach?\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
@@ -135,8 +135,8 @@ class TestListservArchive:
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
         file_dic = {
-            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 48774,
-            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 61569,
+            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 49294,
+            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 68798,
         }
         for filepath, line_nr in file_dic.items():
             assert Path(filepath).is_file()

--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -8,7 +8,11 @@ import yaml
 
 import bigbang
 from bigbang import listserv
-from bigbang.listserv import ListservArchive, ListservList, ListservMessage
+from bigbang.listserv import (
+    ListservArchive,
+    ListservList,
+    ListservMessageParser,
+)
 from config.config import CONFIG
 
 dir_temp = tempfile.gettempdir()
@@ -33,7 +37,7 @@ class TestListservList:
         msg = [
             msg
             for msg in mlist.messages
-            if msg.subject
+            if msg["Subject"]
             == "Re: Update on ITU-T related activities needing attention"
         ][0]
         return msg
@@ -42,36 +46,29 @@ class TestListservList:
         assert len(mlist) == 25
 
     def test__first_message_header(self, msg):
-        assert msg.fromname == "Stephen Hayes"
-        assert msg.fromaddr == "stephen.hayes@ERICSSON.COM"
-        assert msg.toname == "Stephen Hayes"
-        assert msg.toaddr == "stephen.hayes@ERICSSON.COM"
-        assert msg.date == "Mon May  8 10:47:41 2017"
+        assert msg["From"] == "Stephen Hayes <stephen.hayes@ERICSSON.COM>"
+        assert msg["To"] == "Stephen Hayes <stephen.hayes@ERICSSON.COM>"
+        assert msg["Date"] == "Mon, 08 May 2017 10:47:41 -0000"
 
     def test__first_message_body(self, msg):
-        assert msg.body.split("\n")[3] == "Hi,"
-        assert len(msg.body) == 24129
+        assert msg.get_payload().split("\n")[3] == "Hi,"
+        assert len(msg.get_payload()) == 24809
 
     def test__to_dict(self, mlist):
         dic = mlist.to_dict()
-        assert len(list(dic.keys())) == 8
+        assert len(list(dic.keys())) == 10
         assert len(dic[list(dic.keys())[0]]) == 25
-
-    def test__to_pandas_dataframe(self, mlist):
-        df = mlist.to_pandas_dataframe()
-        assert len(df.columns.values) == 8
-        assert len(df.index.values) == 25
 
     def test__to_mbox(self, mlist):
         mlist.to_mbox(dir_temp, filename=mlist.name)
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 41623
+        assert len(lines) == 48738
         assert "What do you think of the approach?\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
-    
+
     def test__missing_date_in_message(self, mlist):
         """
         Test that when a message has no date show, a default value
@@ -79,16 +76,17 @@ class TestListservList:
         msg = [
             msg
             for msg in mlist.messages
-            if msg.subject
-            == "R: How to proceed with ITUT-AH"
+            if msg["Subject"] == "R: How to proceed with ITUT-AH"
         ][0]
-        assert msg.date == None
-        msg.to_mbox(filepath=f'{dir_temp}/msg_test.mbox')
+        assert msg["Date"] is None
+        ListservMessageParser().to_mbox(
+            msg, filepath=f"{dir_temp}/msg_test.mbox"
+        )
         file_temp_mbox = f"{dir_temp}/msg_test.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 478
-        assert "Date: None'\n" in lines
+        assert len(lines) == 546
+        assert "Inviato: mercoled=3DEC 15 marzo 2017 16:06\n" in lines
         f.close()
         Path(file_temp_mbox).unlink()
 
@@ -118,29 +116,22 @@ class TestListservArchive:
         msg = [
             msg
             for msg in arch.lists[mtce_index].messages
-            if msg.subject == "test email - please ignore"
+            if msg["Subject"] == "test email - please ignore"
         ][0]
-        assert msg.fromname == "Jain Puneet"
-        assert msg.fromaddr == "puneet.jain@INTEL.COM"
-        assert msg.toname == "Jain Puneet"
-        assert msg.toaddr == "puneet.jain@INTEL.COM"
-        assert msg.date == "Thu Feb 28 18:58:18 2013"
+        assert msg["From"] == "Jain Puneet <puneet.jain@INTEL.COM>"
+        assert msg["To"] == "Jain Puneet <puneet.jain@INTEL.COM>"
+        assert msg["Date"] == "Thu, 28 Feb 2013 18:58:18 -0000"
 
     def test__to_dict(self, arch):
         dic = arch.to_dict()
-        assert len(list(dic.keys())) == 9
+        assert len(list(dic.keys())) == 11
         assert len(dic[list(dic.keys())[0]]) == 82
-
-    def test__to_pandas_dataframe(self, arch):
-        df = arch.to_pandas_dataframe()
-        assert len(df.columns.values) == 9
-        assert len(df.index.values) == 82
 
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
         file_dic = {
-            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 41623,
-            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 61211,
+            f"{dir_temp}/3GPP_TSG_SA_ITUT_AHG.mbox": 48738,
+            f"{dir_temp}/3GPP_TSG_SA_WG2_MTCE.mbox": 61496,
         }
         for filepath, line_nr in file_dic.items():
             assert Path(filepath).is_file()
@@ -153,7 +144,7 @@ class TestListservArchive:
 
 @mock.patch("bigbang.listserv.ask_for_input", return_value="check")
 def test__get_login_from_terminal(input):
-    """ test if login keys will be documented """
+    """test if login keys will be documented"""
     file_auth = dir_temp + "/authentication.yaml"
     _, _ = listserv.get_login_from_terminal(
         username=None, password=None, file_auth=file_auth

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -41,7 +41,7 @@ class TestListservMessageParser:
             url=url_message,
             fields="total",
         )
-        assert msg["From"] == '"iceeng 10"'
+        assert msg["From"] == "iceeng-10"
         assert msg["To"] is None
 
     @pytest.fixture(name="msg", scope="module")
@@ -67,9 +67,9 @@ class TestListservMessageParser:
             msg["Subject"]
             == "10th International Conference on Electrical Engineering (ICEENG'10)"
         )
-        assert msg["From"] == '"iceeng 10"'
+        assert msg["From"] == "iceeng-10"
         assert msg["To"] is None
-        assert msg["Date"] == "Mon, 23 Nov 2015 11:00:37 -0000"
+        assert msg["Date"] == "Mon, 23 Nov 2015 11:00:37 +0000"
         assert (
             msg["Content-Type"]
             == 'text/plain; charset="utf-8"; Content-Type="multipart/mixed"'
@@ -97,7 +97,7 @@ class TestListservMessageParser:
             url=url_message,
             fields="body",
         )
-        assert str(msg["Subject"]) == "None"
+        assert str(msg["Subject"]) == ""
 
     def test__to_dict(self, msg):
         dic = ListservMessageParser.to_dict(msg)
@@ -132,7 +132,7 @@ class TestListservList:
             },
             login=auth_key,
         )
-        assert mlist.messages[0]["From"] == '"iceeng 10"'
+        assert mlist.messages[0]["From"] == "iceeng-10"
         assert mlist.messages[0]["To"] is None
 
     @pytest.fixture(name="mlist", scope="module")
@@ -170,7 +170,7 @@ class TestListservList:
         assert len(lines) == 9
         assert (
             lines[1]
-            == "Subject: 10th International Conference on Electrical Engineering (ICEENG'10)\n"
+            == "subject: 10th International Conference on Electrical Engineering (ICEENG'10)\n"
         )
         f.close()
         Path(file_temp_mbox).unlink()
@@ -207,7 +207,7 @@ class TestListservArchive:
 
     def test__to_dict(self, arch):
         dic = arch.to_dict()
-        assert len(list(dic.keys())) == 8
+        assert len(list(dic.keys())) == 7
         assert len(dic[list(dic.keys())[0]]) == 1
 
     def test__to_mbox(self, arch):

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -85,7 +85,7 @@ class TestListservMessageParser:
             url=url_message,
             fields="header",
         )
-        assert str(msg.get_payload().split()[0]) == "None"
+        assert msg.get_payload() is None
 
     def test__only_body_from_url(self):
         msg_parser = ListservMessageParser(
@@ -159,7 +159,7 @@ class TestListservList:
 
     def test__to_dict(self, mlist):
         dic = mlist.to_dict()
-        assert len(list(dic.keys())) == 9
+        assert len(list(dic.keys())) == 7
         assert len(dic[list(dic.keys())[0]]) == 1
 
     def test__to_mbox(self, mlist):
@@ -167,8 +167,11 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 12
-        assert lines[1] == "Content-Transfer-Encoding: 7bit\n"
+        assert len(lines) == 9
+        assert (
+            lines[1]
+            == "Subject: 10th International Conference on Electrical Engineering (ICEENG'10)\n"
+        )
         f.close()
         Path(file_temp_mbox).unlink()
 
@@ -204,13 +207,13 @@ class TestListservArchive:
 
     def test__to_dict(self, arch):
         dic = arch.to_dict()
-        assert len(list(dic.keys())) == 10
+        assert len(list(dic.keys())) == 8
         assert len(dic[list(dic.keys())[0]]) == 1
 
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
         file_dic = {
-            f"{dir_temp}/IEEE-TEST.mbox": 10,
+            f"{dir_temp}/IEEE-TEST.mbox": 7,
         }
         for filepath, line_nr in file_dic.items():
             assert Path(filepath).is_file()

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -1,4 +1,3 @@
-from time import time
 import os
 import tempfile
 from pathlib import Path
@@ -9,7 +8,11 @@ import yaml
 
 import bigbang
 from bigbang import listserv
-from bigbang.listserv import ListservArchive, ListservList, ListservMessage
+from bigbang.listserv import (
+    ListservArchive,
+    ListservList,
+    ListservMessageParser,
+)
 from config.config import CONFIG
 
 dir_temp = tempfile.gettempdir()
@@ -21,7 +24,7 @@ file_auth = CONFIG.config_path + "authentication.yaml"
 auth_key_mock = {"username": "bla", "password": "bla"}
 
 
-class TestListservMessage:
+class TestListservMessageParser:
     @pytest.mark.skipif(
         not os.path.isfile(file_auth),
         reason="Key to log into LISTSERV could not be found",
@@ -29,65 +32,83 @@ class TestListservMessage:
     def test__from_url_with_login(self):
         with open(file_auth, "r") as stream:
             auth_key = yaml.safe_load(stream)
-        msg = ListservMessage.from_url(
+        msg_parser = ListservMessageParser(
+            website=True,
+            login=auth_key,
+        )
+        msg = msg_parser.from_url(
             list_name="IEEE-TEST",
             url=url_message,
             fields="total",
-            login=auth_key,
         )
-        assert msg.fromaddr == "[log in to unmask]"
-        assert msg.toaddr == None
+        assert msg["From"] == '"iceeng 10"'
+        assert msg["To"] is None
 
     @pytest.fixture(name="msg", scope="module")
     def get_message(self):
-        msg = ListservMessage.from_url(
+        msg_parser = ListservMessageParser(
+            website=True,
+            login=auth_key_mock,
+        )
+        msg = msg_parser.from_url(
             list_name="IEEE-TEST",
             url=url_message,
             fields="total",
-            login=auth_key_mock,
         )
         return msg
 
     def test__message_content(self, msg):
-        assert msg.body.split("C")[0] == "=================================================\n"
-        assert msg.subject == "10th International Conference on Electrical Engineering (ICEENG'10)"
-        assert msg.fromname == "iceeng 10"
-        assert msg.fromaddr == "[log in to unmask]"
-        assert msg.toname == None
-        assert msg.toaddr == None
-        assert msg.date == "Mon Nov 23 11:00:37 2015"
-        assert msg.contenttype == "multipart/mixed"
+        line = msg.get_payload().split("C")[1].split("=")[0]
+        assert (
+            line
+            == "onference Announcement: Full Paper Submission Deadline (December 31, 2015)\n"
+        )
+        assert (
+            msg["Subject"]
+            == "10th International Conference on Electrical Engineering (ICEENG'10)"
+        )
+        assert msg["From"] == '"iceeng 10"'
+        assert msg["To"] is None
+        assert msg["Date"] == "Mon, 23 Nov 2015 11:00:37 -0000"
+        assert (
+            msg["Content-Type"]
+            == 'text/plain; charset="utf-8"; Content-Type="multipart/mixed"'
+        )
 
     def test__only_header_from_url(self):
-        msg = ListservMessage.from_url(
+        msg_parser = ListservMessageParser(
+            website=True,
+            login=auth_key_mock,
+        )
+        msg = msg_parser.from_url(
             list_name="IEEE-TEST",
             url=url_message,
             fields="header",
-            login=auth_key_mock,
         )
-        assert msg.body is None
+        assert str(msg.get_payload().split()[0]) == "None"
 
     def test__only_body_from_url(self):
-        msg = ListservMessage.from_url(
+        msg_parser = ListservMessageParser(
+            website=True,
+            login=auth_key_mock,
+        )
+        msg = msg_parser.from_url(
             list_name="IEEE-TEST",
             url=url_message,
             fields="body",
-            login=auth_key_mock,
         )
-        assert msg.subject is None
+        assert str(msg["Subject"]) == "None"
 
     def test__to_dict(self, msg):
-        dic = msg.to_dict()
-        assert len(list(dic.keys())) == 8
+        dic = ListservMessageParser.to_dict(msg)
+        assert len(list(dic.keys())) == 9
 
     def test__to_mbox(self, msg):
-        msg.to_mbox(file_temp_mbox)
+        ListservMessageParser.to_mbox(msg, file_temp_mbox)
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 57
-        assert (
-            lines[1] == "From b'[log in to unmask]' Mon Nov 23 11:00:37 2015\n"
-        )
+        assert len(lines) == 75
+        assert lines[1] == "Content-Transfer-Encoding: quoted-printable\n"
         f.close()
         Path(file_temp_mbox).unlink()
 
@@ -111,8 +132,8 @@ class TestListservList:
             },
             login=auth_key,
         )
-        assert mlist.messages[0].fromaddr == "[log in to unmask]"
-        assert mlist.messages[0].toaddr == None
+        assert mlist.messages[0]["From"] == '"iceeng 10"'
+        assert mlist.messages[0]["To"] is None
 
     @pytest.fixture(name="mlist", scope="module")
     def get_mailinglist(self):
@@ -131,28 +152,23 @@ class TestListservList:
         assert mlist.name == "IEEE-TEST"
         assert mlist.source == url_list
         assert len(mlist) == 1
-        assert mlist.messages[0].subject == "10th International Conference on Electrical Engineering (ICEENG'10)"
+        assert (
+            mlist.messages[0]["Subject"]
+            == "10th International Conference on Electrical Engineering (ICEENG'10)"
+        )
 
     def test__to_dict(self, mlist):
         dic = mlist.to_dict()
-        assert len(list(dic.keys())) == 8
+        assert len(list(dic.keys())) == 9
         assert len(dic[list(dic.keys())[0]]) == 1
-
-    def test__to_pandas_dataframe(self, mlist):
-        df = mlist.to_pandas_dataframe()
-        assert len(df.columns.values) == 8
-        assert len(df.index.values) == 1
 
     def test__to_mbox(self, mlist):
         mlist.to_mbox(dir_temp, filename=mlist.name)
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 10
-        assert (
-            lines[1]
-            == "From b'[log in to unmask]' Mon Nov 23 11:00:37 2015\n"
-        )
+        assert len(lines) == 12
+        assert lines[1] == "Content-Transfer-Encoding: 7bit\n"
         f.close()
         Path(file_temp_mbox).unlink()
 
@@ -160,7 +176,6 @@ class TestListservList:
 class TestListservArchive:
     @pytest.fixture(name="arch", scope="session")
     def get_mailarchive(self):
-        start = time()
         arch = ListservArchive.from_url(
             name="IEEE",
             url_root=url_archive,
@@ -178,23 +193,19 @@ class TestListservArchive:
         return arch
 
     def test__archive_content(self, arch):
-        mlist_names = [mlist.name for mlist in arch.lists]
-        mlist_len = [len(mlist) for mlist in arch.lists]
         assert arch.name == "IEEE"
         assert arch.url == url_archive
         assert len(arch) == 1
         assert len(arch.lists[0]) == 1
-        assert arch.lists[0].messages[0].subject == "10th International Conference on Electrical Engineering (ICEENG'10)"
+        assert (
+            arch.lists[0].messages[0]["Subject"]
+            == "10th International Conference on Electrical Engineering (ICEENG'10)"
+        )
 
     def test__to_dict(self, arch):
         dic = arch.to_dict()
-        assert len(list(dic.keys())) == 9
+        assert len(list(dic.keys())) == 10
         assert len(dic[list(dic.keys())[0]]) == 1
-
-    def test__to_pandas_dataframe(self, arch):
-        df = arch.to_pandas_dataframe()
-        assert len(df.columns.values) == 9
-        assert len(df.index.values) == 1
 
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
@@ -205,6 +216,7 @@ class TestListservArchive:
             assert Path(filepath).is_file()
             f = open(filepath, "r")
             lines = f.readlines()
+            lines = [ll for ll in lines if len(ll) > 1]
             assert line_nr == len(lines)
             f.close()
             Path(filepath).unlink()
@@ -212,7 +224,7 @@ class TestListservArchive:
 
 @mock.patch("bigbang.listserv.ask_for_input", return_value="check")
 def test__get_login_from_terminal(input):
-    """ test if login keys will be documented """
+    """test if login keys will be documented"""
     file_auth = dir_temp + "/authentication.yaml"
     _, _ = listserv.get_login_from_terminal(
         username=None, password=None, file_auth=file_auth

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -167,7 +167,7 @@ class TestListservList:
         file_temp_mbox = f"{dir_temp}/{mlist.name}.mbox"
         f = open(file_temp_mbox, "r")
         lines = f.readlines()
-        assert len(lines) == 9
+        assert len(lines) == 18
         assert (
             lines[1]
             == "subject: 10th International Conference on Electrical Engineering (ICEENG'10)\n"
@@ -213,7 +213,7 @@ class TestListservArchive:
     def test__to_mbox(self, arch):
         arch.to_mbox(dir_temp)
         file_dic = {
-            f"{dir_temp}/IEEE-TEST.mbox": 7,
+            f"{dir_temp}/IEEE-TEST.mbox": 14,
         }
         for filepath, line_nr in file_dic.items():
             assert Path(filepath).is_file()


### PR DESCRIPTION
This PR addresses #434.

It inclues:
- changing `ListservMessage` to `ListservMessageParser` and using `email.message.EmailMessage` together with `mailbox.mboxMessage` to represent a `ListservMessage`
- editing listserv tests to according to the changes above
- isort and black formatting have become incompatible so that we continue to use only black code formatting
- edit the priority in which message payloads are stored in the following way: 1) text/plain 2) text/html, otherwise return None
- some messages seems to cause error executing `mailbox.mbox()` `.add()`, they are captured on exception and recorded through the logger