### PR TITLE
improve listserv unit tests

### DIFF
--- a/tests/unit/test_listserv.py
+++ b/tests/unit/test_listserv.py
@@ -80,6 +80,24 @@ class TestListservMessageParser:
 
 class TestListservList:
 
+    def test__from_mbox(self):
+        mlist = ListservList.from_mbox(
+            name="3GPP_MENTORING",
+            filepath=CONFIG.test_data_path + "3GPP_mbox/3GPP_MENTORING.mbox",
+        )
+        assert len(mlist) == 27
+        assert mlist.messages[0]["From"] == "John M Meredith <[log in to unmask]>"
+    
+    def test__from_listserv_files(self):
+        filepath = CONFIG.test_data_path + \
+            "3GPP/3GPP_TSG_SA_ITUT_AHG/3GPP_TSG_SA_ITUT_AHG.LOG1703B"
+        mlist = ListservList.from_listserv_files(
+            name="3GPP_TSG_SA_ITUT_AHG",
+            filepaths=[filepath],
+        )
+        assert len(mlist) == 1
+        assert mlist.messages[0]["From"] == "Kevin Holley <kevin.holley@BT.COM>"
+
     def test__number_of_messages(self, mlist):
         assert len(mlist) == 25
 
@@ -121,6 +139,16 @@ class TestListservList:
 
 
 class TestListservArchive:
+
+    def test__from_mbox(self):
+        march = ListservArchive.from_mbox(
+            name="3GPP_mbox_test",
+            directorypath=CONFIG.test_data_path + "3GPP_mbox/",
+        )
+        assert len(march.lists) == 1
+        assert len(march.lists[0].messages) == 27
+        assert march.lists[0].messages[0]["From"] == "John M Meredith <[log in to unmask]>"
+
     @pytest.fixture(name="arch", scope="session")
     def get_mailarchive(self):
         arch = ListservArchive.from_listserv_directory(

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -114,6 +114,7 @@ class TestListservMessageParser:
 
 
 class TestListservList:
+
     @pytest.mark.skipif(
         not os.path.isfile(file_auth),
         reason="Key to log into LISTSERV could not be found",
@@ -134,9 +135,21 @@ class TestListservList:
         )
         assert mlist.messages[0]["From"] == "iceeng-10"
         assert mlist.messages[0]["To"] is None
+    
+    def test__get_mailinglist_from_messages(self):
+        msgs_urls = [
+            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;a57724f6.2105a",
+            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;fc0a9fdd.2105b",
+        ]
+        mlist = ListservList.from_messages(
+            name="IEEE-TEST",
+            url=url_list,
+            messages=msgs_urls,
+        )
+        assert len(mlist.messages) == 2
 
     @pytest.fixture(name="mlist", scope="module")
-    def get_mailinglist(self):
+    def get_mailinglist_from_url(self):
         mlist = ListservList.from_url(
             name="IEEE-TEST",
             url=url_list,

--- a/tests/webscraping/test_listserv.py
+++ b/tests/webscraping/test_listserv.py
@@ -136,18 +136,6 @@ class TestListservList:
         assert mlist.messages[0]["From"] == "iceeng-10"
         assert mlist.messages[0]["To"] is None
     
-    def test__get_mailinglist_from_messages(self):
-        msgs_urls = [
-            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;a57724f6.2105a",
-            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;fc0a9fdd.2105b",
-        ]
-        mlist = ListservList.from_messages(
-            name="IEEE-TEST",
-            url=url_list,
-            messages=msgs_urls,
-        )
-        assert len(mlist.messages) == 2
-
     @pytest.fixture(name="mlist", scope="module")
     def get_mailinglist_from_url(self):
         mlist = ListservList.from_url(
@@ -160,6 +148,19 @@ class TestListservList:
             login=auth_key_mock,
         )
         return mlist
+    
+    def test__get_mailinglist_from_messages(self):
+        msgs_urls = [
+            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;a57724f6.2105a",
+            "https://listserv.ieee.org/cgi-bin/wa?A2=IEEE-TEST;fc0a9fdd.2105b",
+        ]
+        mlist = ListservList.from_messages(
+            name="IEEE-TEST",
+            url=url_list,
+            messages=msgs_urls,
+            login=auth_key_mock,
+        )
+        assert len(mlist.messages) == 2
 
     def test__mailinglist_content(self, mlist):
         assert mlist.name == "IEEE-TEST"


### PR DESCRIPTION
This PR includes more unit tests for better code coverage of modules that enable to read Listserv 16.5 mailing archives of different file formats from disk.