### PR TITLE
Add data access permit application

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ If you have problems installing, you might want to have a look at the video tuto
 
 [![BigBang Video Tutorial](http://img.youtube.com/vi/JWimku8JVqE/0.jpg)](http://www.youtube.com/watch?v=JWimku8JVqE "BigBang Tutorial")
 
+## Data Access Permit Application
+The mailing-list archives are large and time consuming to scrape from the web. That is why we keep a complete and up-to-date copy of it in .mbox format that can easily be converted into other data structures to make its analysis as easy as possible. If you would like to obtain access to these archives, we would ask you send us your filled in [data access permit application](https://github.com/datactive/bigbang/blob/master/data_access_permit_application.md) to [bigbang-dev mailing list](https://lists.ghserv.net/mailman/listinfo/bigbang-dev).
+
 ## License
 
 MIT, see [LICENSE](LICENSE) for its text. This license may be changed at any time according to the principles of the project [Governance](https://github.com/datactive/bigbang/wiki/Governance).

--- a/data_access_permit_application.md
+++ b/data_access_permit_application.md
@@ -1,0 +1,36 @@
+BigBang - Data Access Permit Application
+
+# Commitments
+Every person named below makes this statement of commitment.
+
+- I shall not hand over the data to outside parties.
+- I shall store the data in a safe and secure manner.
+- If I become aware of a data security violation associated with the data I shall report this to the BigBang mailinglist.
+- I will treat the data in accordance and in compliance with the licenses of the original data providers, such as the 3GPP, IETF, ICANN, RIPE, and others.
+- This data should be treated in accordance with the Ethical Principles and Guidelines for the Protection of Human Subjects of Research as outlined in the [Belmont Report](https://www.hhs.gov/ohrp/sites/default/files/the-belmont-report-508c_FINAL.pdf) [0].
+
+# Applicant
+Surname:
+First name:
+Email:
+Research institute, educational establishment or other facility:
+Title:
+Degree:
+
+# Other Research Group Members
+Surname:
+First name:
+Email:
+Research institute, educational establishment or other facility:
+Title:
+Degree:
+
+# Research/Application Description
+Name & Subject of the research/application (short description):
+Has BigBang granted an earlier permit:
+    [] Yes, by whom (name) and when (date):
+    [] No
+    
+    
+# REFERENCES
+[0] National Commission for the Protection of Human Subjects of Biomedical and Behavioral Research. The Belmont Report: Ethical Principles and Guidelines for the Protection of Human Subjects of Research. [Bethesda, Md.]: The Commission, 1978.


### PR DESCRIPTION
This PR contributes:
- data access permit application to be filled out by anyone who is interested to obtain access to complete and up-to-date mailing list archives
- include it in the git-repo README.md