### PR TITLE
Doc suggestions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,20 +7,13 @@ Welcome to BigBang's documentation!
 ===================================
 
 ``BigBang`` is a toolkit for studying processes of open collaboration and
-deliberation via analysis of the communciations records.
+deliberation via analysis of the communications records.
 
 BigBang is open source software hosted on `GitHub <https://github.com/datactive/bigbang>`_.
 
-It currently supports analyzing mailing lists from Sourceforge, Mailman,
-ListServ or .mbox files.
-BigBang provides tools for efficiently scraping this data
-from on-line sources.
+It currently supports scraping public Sourceforge, Mailman, and ListServ mailing list archives and stores the results as Mbox or CSV files using Pythons mailbox and Pandas packages. A variety of modules for analysis and visualisation are provided to gain valuable insight from the obtained data.
 
-It also provides a variety of preprocessing scripts to assist researchers in gaining valuable insight from this data.
-
-Last but not least, BigBang is a community of researchers sharing code and best practices. BigBang comes with a large directory of `examples` showing how to use data science tools to study communications data.
-These examples are designed to support data science and communictions
-research pedagogy.
+Last but not least, BigBang is a community of researchers sharing code and best practices. BigBang comes with a large directory of `examples` showing how to use data science tools to study communications data. These examples are designed as tutorial and support data science and research pedagogy.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -3,7 +3,7 @@ Motivation
 
 BigBang was originally designed to study communities developing
 open sources scientific software.
-It was quickly thereafter adopte by researchers studying Internet
+It was quickly thereafter adopted by researchers studying Internet
 and network standards-setting.
 Organizations such as the IETF conduct much of their technical work
 via open mailing list and document records.


### PR DESCRIPTION
This PR contains the following changed to the RTD:
- docs/index.rst: reformulation and spelling
- docs/intro.rst: spelling

Furthermore, I was thinking about the following

```
**Getting Started**
- Installation
- Motivation  (place this above Installation)
- License

**Documentation**
- Data sources
- Git as data source  (make this part of 'Data sources')
- API Documentation

(Should we give another bullet point to the preprocessing scripts for analysis and visualisation?)

**Community**
- Contribution (add this, to info on communication channels, code formatting, etc.)
- Data Access
- Release notes
```