### PR TITLE
Fix ingress test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     - id: black
       language_version: python3
+      additional_dependencies: ['click==8.0.4']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/bigbang/analysis/repo_loader.py
+++ b/bigbang/analysis/repo_loader.py
@@ -89,7 +89,7 @@ def get_files(filepath):
         for filename in fnmatch.filter(filenames, "*.ipynb"):
             try:
                 with open(filename) as fh:
-                    nb = nbformat.reads_json(fh.read())
+                    nb = nbformat.reads(fh.read())
                     export_path = filename.replace(".ipynb", ".py")
                     exporter = PythonExporter()
                     source, meta = exporter.from_notebook_node(nb)

--- a/bigbang/analysis/repo_loader.py
+++ b/bigbang/analysis/repo_loader.py
@@ -10,7 +10,7 @@ import networkx as nx
 import pandas as pd
 import requests
 from nbconvert import PythonExporter
-from nbformat import current as nbformat
+import nbformat
 
 from config.config import CONFIG
 
@@ -89,7 +89,7 @@ def get_files(filepath):
         for filename in fnmatch.filter(filenames, "*.ipynb"):
             try:
                 with open(filename) as fh:
-                    nb = nbformat.reads(fh.read())
+                    nb = nbformat.read(fh.read())
                     export_path = filename.replace(".ipynb", ".py")
                     exporter = PythonExporter()
                     source, meta = exporter.from_notebook_node(nb)

--- a/bigbang/ingress/w3c.py
+++ b/bigbang/ingress/w3c.py
@@ -328,6 +328,8 @@ class W3CMailList(AbstractMailList):
         # wait between loading messages, for politeness
         time.sleep(0.5)
         soup = get_website_content(url)
+        print("get_all_periods_and_their_urls:")
+        print(url)
         periods = []
         urls_of_periods = []
         rows = soup.select("tbody tr")

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.7
   - ipykernel
   - nb_conda_kernels
+  - nbformat>=5.3.0
   - cython
   - beautifulsoup4>=4.9.3
   - coverage>=5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ jupyter
 jsonschema
 GitPython
 matplotlib>=3.3.3
+nbformat>=5.3.0
 networkx>=2.5
 nltk>=3.6.2
 numpy>=1.19.5


### PR DESCRIPTION
This PR contains updates to the Listserv & W3C ingress code and tests.

The [Listserv mail archive](https://listserv.ieee.org/cgi-bin/wa?) of IEEE was updated to Listserv 17 from Listserv 16.5. The new format does not group message within mailing lists into time periods anymore. Therefore the following changes were undertaken:
- automatic recognition if Listserv mail archive has v16.5 or v17.0 format
- A time period selection for Listserv mail archives in v17.0 format is currently not supported which is why the new code tests for `ListservMailListDomain` have been changed to only consider preselected mailing lists by using the function `ListservMailListDomain.from_mailing_lists()`
- Test that save `ListservMailList` and `ListservMailListDomain` to a .mbox file in the temporary folder have been removed as it only worked on Linux OS, but not on Windows or MacOS.

For W3C only the code tests have been change as the previous mailing list that was used to test the ingress has been removed from the public web archive.

Another change that this PR contains is of the `.pre-commit-config.yaml`, because there is unsolved version conflict between the newest update of the code formatting package `black` and a dependency called `click`. Therefore pre-commit needs to be forced to use an older version of `click`.

Fixes the `nbformat` issue.